### PR TITLE
eksik dil anahtarları eklendi.

### DIFF
--- a/tr.json
+++ b/tr.json
@@ -53,5 +53,8 @@
   "The :attribute must contain at least one number.": ":attribute en az bir tane rakam içermelidir.",
   "The :attribute must contain at least one symbol.": ":attribute en az bir tane özel karakter içermelidir.",
   "The :attribute must contain at least one uppercase and one lowercase letter.": ":attribute en az bir tane büyük harf ve küçük harf içermelidir.",
-  "The given :attribute has appeared in a data leak. Please choose a different :attribute.": "Verilen :attribute bir veri sızıntısında ortaya çıktı. Lütfen başka bir :attribute seçiniz."
+  "The given :attribute has appeared in a data leak. Please choose a different :attribute.": "Verilen :attribute bir veri sızıntısında ortaya çıktı. Lütfen başka bir :attribute seçiniz.",
+  "(and :count more errors)": "(ve :count daha fazla hata)",
+  "(and :count more error)": "(ve :count hata)",
+  "The given data was invalid.": "Verilen veri geçersizdi."
 }


### PR DESCRIPTION
[\Illuminate\Validation\ValidationException](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Validation/ValidationException.php) sınıfının [91](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Validation/ValidationException.php#L91) ve [99](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Validation/ValidationException.php#L99) satırlarında kullanılan dil anahtarları eklendi.